### PR TITLE
Fix up chart linting, add docs and lint script (#146)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: gcr.io/kubernetes-charts-ci/test-image:v3.0.1
     steps:
       - checkout
-      - run: ct lint --config .circleci/chart-testing.yaml
+      - run: ct lint --config .circleci/chart-testing.yaml --lint-conf .circleci/lintconf.yaml
   # Technically this only needs to be run on master, but it's good to have it run on every PR
   # so that it is regularly tested.
   publish:

--- a/.circleci/lintconf.yaml
+++ b/.circleci/lintconf.yaml
@@ -1,0 +1,42 @@
+---
+rules:
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments:
+    require-starting-space: true
+    min-spaces-from-content: 1
+  document-end: disable
+  document-start: disable # No --- to start a file
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 0
+  hyphens:
+    max-spaces-after: 1
+  indentation:
+    spaces: consistent
+    indent-sequences: whatever # - list indentation will handle both indentation and without
+    check-multi-line-strings: false
+  key-duplicates: enable
+  line-length: disable # Lines can be any length
+  new-line-at-end-of-file: enable
+  new-lines:
+    type: unix
+  trailing-spaces: enable
+  truthy:
+    level: warning

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,33 @@ argocd app create guestbook --dest-namespace default --dest-server https://kuber
 argocd app sync guestbook
 ```
 
+## New Application Versions
+
+When raising application versions ensure you make the following changes:
+
+- `values.yaml`: Bump all instances of the container image version
+- `Chart.yaml`: Ensure `appVersion` matches the above container image and bump `version`
+
+Please ensure chart version changes adhere to semantic versioning standards:
+
+- Patch: App version patch updates, backwards compatible optional chart features
+- Minor: New chart functionality (sidecars), major application updates or minor non-backwards compatible changes
+- Major: Large chart rewrites, major non-backwards compatible or destructive changes
+
+## Testing Charts
+
+As part of the Continous Intergration system we run Helm's [Chart Testing](https://github.com/helm/chart-testing) tool.
+
+The checks for this tool are stricter than the standard Helm requirements, where fields normally considered optional like `maintainer` are required in the standard spec and must be valid GitHub usernames.
+
+Linting configuration can be found in [lintconf.yaml](.circleci/lintconf.yaml)
+
+The linting can be invoked manually with the following command:
+
+```
+./scripts/lint.sh
+```
+
 ## Publishing Changes
 
 Changes are automatically publish whenever a commit is merged to master. The CI job (see `.circleci/config.yaml`) runs this:

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.4"
 description: A Helm chart for ArgoCD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 1.0.0
+version: 1.0.1
 home: https://github.com/argoproj/argo-helm
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
 keywords:

--- a/charts/argo-ci/Chart.yaml
+++ b/charts/argo-ci/Chart.yaml
@@ -1,5 +1,11 @@
 apiVersion: v1
 description: A Helm chart for Argo-CI
 name: argo-ci
-version: 0.1.4
+version: 0.1.5
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
+appVersion: v1.0.0-alpha2
+home: https://github.com/argoproj/argo-helm
+maintainers:
+  - name: alexec
+  - name: alexmt
+  - name: jessesuen

--- a/charts/argo-ci/values.yaml
+++ b/charts/argo-ci/values.yaml
@@ -9,4 +9,3 @@ argo:
   installMinio: true
   minioBucketName: argo-artifacts
   useReleaseAsInstanceID: true
-  

--- a/charts/argo-events/Chart.yaml
+++ b/charts/argo-events/Chart.yaml
@@ -1,15 +1,16 @@
 apiVersion: v1
 description: A Helm chart to install Argo-Events in k8s Cluster
 name: argo-events
-version: 0.5.1
+version: 0.5.2
 keywords:
-- argo-events
-- sensor-controller
-- gateway-controller
+  - argo-events
+  - sensor-controller
+  - gateway-controller
 sources:
-- https://github.com/argoproj/argo-events
+  - https://github.com/argoproj/argo-events
 maintainers:
-- name: Vaibhav Page
-- name: Matt Magaldi
+  - name: VaibhavPage
+  - name: magaldima
 appVersion: 0.10
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
+home: https://github.com/argoproj/argo-helm

--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,5 +2,11 @@ apiVersion: v1
 appVersion: "v2.4.2"
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.6.2
+version: 0.6.3
 icon: https://raw.githubusercontent.com/argoproj/argo/master/argo.png
+home: https://github.com/argoproj/argo-helm
+maintainers:
+  - name: alexec
+  - name: alexmt
+  - name: jessesuen
+  - name: benjaminws

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eux
+
+SRCROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+for dir in $(find $SRCROOT/charts -mindepth 1 -maxdepth 1 -type d);
+do
+ name=$(basename $dir)
+ echo "Running Helm linting for $name"
+ docker run \
+    -v "$SRCROOT:/workdir" \
+    gcr.io/kubernetes-charts-ci/test-image:v3.0.1 \
+    ct \
+    lint \
+    --config .circleci/chart-testing.yaml \
+    --lint-conf .circleci/lintconf.yaml \
+    --charts "/workdir/charts/${name}"
+done


### PR DESCRIPTION
This updates the Helm linting system with the following changes:

- Import lintconf.yaml with small change to comment distance in order to
match existing values.yaml standards
- Update Chart.yaml and values.yaml in each chart to pass linting
standards
- Maintainers added to each chart from OWNERS + CODEOWNERS, the linter
requires GitHub usernames so argo-events maintainer names were converted
- README updated with documentation around chart standards and testing
- A local shell script added for running lint tests locally

Checklist:

* [ ] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [ ] I have signed the CLA and the build is green.
* [ ] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.